### PR TITLE
fix: make paymentmeans optional when no payment information exists

### DIFF
--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -456,6 +456,17 @@ class PEPPOLGenerator:
 		if not hasattr(self, "root") or self.root is None:
 			return
 
+		# Check if we have any payment information
+		has_payment_info = self.invoice.payment_terms_template or (
+			self.invoice.payment_schedule
+			and any(term.mode_of_payment for term in self.invoice.payment_schedule)
+		)
+
+		# Skip PaymentMeans if no payment information is available
+		# PaymentMeans has cardinality 0..n in Peppol BIS Billing 3.0, making it optional
+		if not has_payment_info:
+			return
+
 		# Add PaymentMeans
 		payment_means = ET.SubElement(self.root, f"{{{self.namespaces['cac']}}}PaymentMeans")
 


### PR DESCRIPTION
**Problem:**
The generator always created a `PaymentMeans` element with default code "ZZZ", causing validation errors when invoices had no payment terms or payment schedule defined.

**Solution:**
Skip the `PaymentMeans` element entirely when no payment information is available. This respects the Peppol BIS Billing 3.0 specification where `PaymentMeans` has 0..n cardinality (optional).

**Changes:**
- Added check for payment information before creating PaymentMeans element
- Early return if neither `payment_terms_template` nor `payment_schedule` with `mode_of_payment` exists

**Result:**
Invoices without payment information now pass Peppol validation without payment means errors.