### PR TITLE
chore: default uom assignment for "hour"

### DIFF
--- a/edocument/edocument/profiles/peppol/setup_peppol_codes.py
+++ b/edocument/edocument/profiles/peppol/setup_peppol_codes.py
@@ -401,6 +401,7 @@ def create_erpnext_mappings():
 		("cm", "CMT"),
 		("Mm", "MMT"),
 		("mm", "MMT"),
+		("Hour", "HUR"),
 		("Hr", "HUR"),
 		("hr", "HUR"),
 		("Day", "DAY"),


### PR DESCRIPTION
Assign the uom "Hour" that ERPNext creates by default to the common code "HUR"