### PR TITLE
fix: profile detection for incoming xml

### DIFF
--- a/edocument/edocument/doctype/edocument/edocument.py
+++ b/edocument/edocument/doctype/edocument/edocument.py
@@ -23,9 +23,6 @@ def _detect_profile_from_xml(xml_bytes: bytes) -> str | None:
 
 		root = ET.fromstring(xml_bytes)
 
-		# Get all namespaces declared in the XML document
-		all_xml_namespaces = set(root.nsmap.values()) if root.nsmap else set()
-
 		# Get all profiles
 		profiles = frappe.get_all(
 			"EDocument Profile",
@@ -41,11 +38,8 @@ def _detect_profile_from_xml(xml_bytes: bytes) -> str | None:
 			if not namespace or not element_name or not identifier_value:
 				continue
 
-			# Check if the profile's namespace exists in the XML
-			if namespace not in all_xml_namespaces:
-				continue
-
 			# Find element in the profile's namespace
+			# findall works regardless of where the namespace is declared (root or child elements)
 			elem = root.findall(f".//{{{namespace}}}{element_name}")
 			if elem and elem[0].text:
 				if elem[0].text.strip() == identifier_value:


### PR DESCRIPTION
Problem:
Profile detection failed for XML documents where namespaces were declared on child elements instead of the root element.

Root Cause:
The code checked if the required namespace existed in root.nsmap before searching for the identifier element:

Fix:
Removed the unnecessary namespace pre-check. The findall() call already handles this naturally - it searches by namespace URI regardless of where it's declared, returning an empty list if the element doesn't exist.

Result:
Profile detection now works for both XML formats:
- Standard: namespaces declared on root (xmlns:cbc="...")
- Alternative: namespaces declared per-element (xmlns:ns0="..." on each child)