### PR TITLE
fix: Fix differentiate warning error

### DIFF
--- a/edocument/edocument/doctype/edocument/edocument.py
+++ b/edocument/edocument/doctype/edocument/edocument.py
@@ -197,7 +197,7 @@ class EDocument(Document):
 		# Combine errors and warnings in the error field
 		error_text_parts = []
 		if error_msg:
-			error_text_parts.append(error_msg)
+			error_text_parts.append(f"Errors:\n{error_msg}")
 		if warnings:
 			warnings_text = "\n".join(warnings)
 			error_text_parts.append(f"Warnings:\n{warnings_text}")

--- a/edocument/edocument/validator.py
+++ b/edocument/edocument/validator.py
@@ -162,17 +162,27 @@ def validate_xml_against_schematron_file(
 
 	# Parse SVRL report
 	root = objectify.fromstring(report.encode("utf-8"))
-	failed_asserts = root.xpath(
-		"//svrl:failed-assert/svrl:text",
-		namespaces={"svrl": "http://purl.oclc.org/dsdl/svrl"},
-	)
-	warnings = root.xpath(
-		"//svrl:successful-report/svrl:text",
-		namespaces={"svrl": "http://purl.oclc.org/dsdl/svrl"},
+	svrl_ns = {"svrl": "http://purl.oclc.org/dsdl/svrl"}
+
+	# Errors: failed-assert WITHOUT flag="warning" (fatal or no flag)
+	error_asserts = root.xpath(
+		"//svrl:failed-assert[not(@flag='warning')]/svrl:text",
+		namespaces=svrl_ns,
 	)
 
-	errors = [assertion.text.strip() for assertion in failed_asserts if assertion.text]
-	warnings = [warning.text.strip() for warning in warnings if warning.text]
+	# Warnings: failed-assert WITH flag="warning" + all successful-report
+	warning_asserts = root.xpath(
+		"//svrl:failed-assert[@flag='warning']/svrl:text",
+		namespaces=svrl_ns,
+	)
+	successful_reports = root.xpath(
+		"//svrl:successful-report/svrl:text",
+		namespaces=svrl_ns,
+	)
+
+	errors = [assertion.text.strip() for assertion in error_asserts if assertion.text]
+	warnings = [w.text.strip() for w in warning_asserts if w.text]
+	warnings.extend([r.text.strip() for r in successful_reports if r.text])
 
 	return errors, warnings
 


### PR DESCRIPTION
The error field now displays both sections with consistent formatting:
   - Errors: (heading) followed by error messages
   - Warnings: (heading) followed by warning messages
in case of only warning, status field is set as validation passed