### PR TITLE
fix: edocument uses draft invoice name instead of final name after submit

### DIFF
--- a/edocument/edocument/custom/sales_invoice.py
+++ b/edocument/edocument/custom/sales_invoice.py
@@ -123,8 +123,10 @@ def on_update(doc, method):
 
 
 def before_submit(doc, method):
-	"""Create and validate EDocument before Sales Invoice is submitted.
+	"""Validate EDocument before Sales Invoice is submitted.
 
+	This hook only performs validation if an EDocument already exists.
+	Otherwise EDocument creation happens in on_submit to use the final invoice name.
 	Blocks submission if EDocument validation fails (unless ignore_validation_error is set).
 	"""
 	# Only process if edocument_profile is set
@@ -140,5 +142,92 @@ def before_submit(doc, method):
 	if not profile_settings.get("edocument_generation_on_submit"):
 		return
 
-	ignore_validation_error = profile_settings.get("ignore_validation_error_for_edocument_generation")
-	_create_edocument(doc, ignore_validation_error=ignore_validation_error)
+	# Check if EDocument already exists (created during save)
+	existing_edocument = frappe.db.exists(
+		"EDocument",
+		{
+			"edocument_source_type": doc.doctype,
+			"edocument_source_document": doc.name,
+		},
+	)
+
+	# If EDocument exists and we should block on validation error, validate it now
+	if existing_edocument:
+		ignore_validation_error = profile_settings.get("ignore_validation_error_for_edocument_generation")
+		if not ignore_validation_error:
+			edocument = frappe.get_doc("EDocument", existing_edocument)
+			if edocument.status == "Validation Failed":
+				frappe.throw(
+					_("EDocument {0} validation failed: {1}").format(
+						frappe.bold(edocument.name), edocument.error or _("Unknown error")
+					)
+				)
+
+
+def on_submit(doc, method):
+	"""Create or regenerate EDocument after Sales Invoice is submitted.
+
+	This ensures the eDocument uses the final invoice name, not the draft name.
+	"""
+	# Only process if edocument_profile is set
+	if not doc.edocument_profile:
+		return
+
+	# Get profile settings
+	profile_settings = _get_profile_settings(doc.edocument_profile)
+	if not profile_settings:
+		return
+
+	# Check if generation on submit is enabled
+	if not profile_settings.get("edocument_generation_on_submit"):
+		return
+
+	# Check if EDocument already exists (created during save)
+	existing_edocument = frappe.db.exists(
+		"EDocument",
+		{
+			"edocument_source_type": doc.doctype,
+			"edocument_source_document": doc.name,
+		},
+	)
+
+	if existing_edocument:
+		# EDocument exists - regenerate XML with final invoice name
+		edocument = frappe.get_doc("EDocument", existing_edocument)
+
+		# Delete existing XML files
+		xml_files = frappe.get_all(
+			"File",
+			filters={
+				"attached_to_doctype": "EDocument",
+				"attached_to_name": edocument.name,
+				"file_name": ["like", "%.xml"],
+			},
+			pluck="name",
+		)
+		for file_name in xml_files:
+			frappe.delete_doc("File", file_name, ignore_permissions=True)
+
+		# Regenerate XML
+		edocument.generate_xml()
+
+		if edocument.status == "Validation Successful":
+			frappe.msgprint(
+				_("EDocument {0} regenerated with final invoice name and validated successfully").format(
+					frappe.bold(edocument.name)
+				),
+				indicator="green",
+				alert=True,
+			)
+		elif edocument.status == "Validation Failed":
+			frappe.msgprint(
+				_("EDocument {0} regenerated but validation failed: {1}").format(
+					frappe.bold(edocument.name), edocument.error or _("Unknown error")
+				),
+				indicator="orange",
+				alert=True,
+			)
+	else:
+		# EDocument doesn't exist - create it now with final invoice name
+		ignore_validation_error = profile_settings.get("ignore_validation_error_for_edocument_generation")
+		_create_edocument(doc, ignore_validation_error=ignore_validation_error)

--- a/edocument/hooks.py
+++ b/edocument/hooks.py
@@ -137,6 +137,7 @@ doc_events = {
 	"Sales Invoice": {
 		"on_update": "edocument.edocument.custom.sales_invoice.on_update",
 		"before_submit": "edocument.edocument.custom.sales_invoice.before_submit",
+		"on_submit": "edocument.edocument.custom.sales_invoice.on_submit",
 	},
 	"Purchase Invoice": {
 		"on_update": "edocument.edocument.custom.purchase_invoice.on_update",


### PR DESCRIPTION
### Problem
When a Sales Invoice was submitted, the generated eDocument XML retained the draft invoice name instead of updating to the final invoice name. This occurred because XML generation happened in the `before_submit` hook, before the invoice received its final name.
Fixes https://github.com/prilk-consulting/edocument/issues/21

### Root Cause
In Frappe's document lifecycle:
1. `before_submit` hook executes while document still has draft name
2. XML was generated at this point with the draft name
3. After `before_submit` completes, document gets its final name
4. XML was never updated with the final name

### Solution
Split the submit workflow between two hooks:

1. **`before_submit`** - Only validates existing edocuments
   - Checks if edocument exists
   - Validates status to potentially block submission
   - Does NOT create or regenerate XML

2. **`on_submit` (new)** - Creates/regenerates edocuments with final invoice name
   - Executes after invoice has final name
   - If edocument exists: deletes old XML files and calls `generate_xml()`
   - If edocument doesn't exist: creates new one with final name

### Behavior
**Scenario 1: `edocument_generation_on_save` enabled**
- Save → eDocument created with draft name
- Submit → XML regenerated with final name

**Scenario 2: `edocument_generation_on_save` disabled**
- Save → No eDocument created
- Submit → eDocument created with final name

Both scenarios now produce edocuments with the correct final invoice name.