### PR TITLE
feat:PEPPOL tax category handling for Z, E, O

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ Then, you can map a **Common Code** from **Code List** "UNTDID.4461", e.g. "Cred
 
 Please note that the e-document standard only supports one payment means per invoice, so you should not specify multiple **Modes of Payment** in the same invoice.
 
+### VAT Exempt and Out of Scope Items
+
+Most invoices use standard VAT rates (S) or zero-rated VAT (Z, automatically detected for 0% rates). For special cases:
+
+- **VAT Exempt (E)**: Create a **Tax Category** (e.g., "VAT Exempt") and map it to code "E" in **Common Code**. Use this tax category on invoices with exempt items like books, education, or healthcare.
+
+- **Out of Scope (O)**: Create a **Tax Category** (e.g., "Out of Scope") and map it to code "O" in **Common Code**. Use for non-business transactions or items not subject to VAT. When any invoice line uses "O", VAT identifiers are automatically omitted from the entire invoice per PEPPOL rules.
+
+For item-specific tax treatment, map codes to **Item**, **Item Tax Template** or **Account** instead of **Tax Category**.
+
 ## How to Guide
 
 ### Master Data Configuration

--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -454,24 +454,11 @@ class PEPPOLGenerator:
 			taxable_amount.text = str(flt(data["taxable_amount"], 2))
 			taxable_amount.set("currencyID", self.invoice.currency)
 
-			# Use tax_amount_after_discount_amount directly (already correctly calculated by ERPNext)
 			tax_amount = ET.SubElement(tax_subtotal, f"{{{self.namespaces['cbc']}}}TaxAmount")
 			tax_amount.text = str(flt(data["tax_amount"], 2))
 			tax_amount.set("currencyID", self.invoice.currency)
 
 			tax_category = ET.SubElement(tax_subtotal, f"{{{self.namespaces['cac']}}}TaxCategory")
-
-			# Get category code dynamically from first item with this rate
-			category_code = None
-			sample_item = None
-			for item in self.invoice.items:
-				if self._get_item_tax_rate(item) == rate:
-					sample_item = item
-					category_code = self.get_vat_category_code(self.invoice, item=item)
-					break
-
-			if not category_code:
-				category_code = "S"  # Fallback to standard
 
 			category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
 			category_id.text = category_code
@@ -481,7 +468,6 @@ class PEPPOLGenerator:
 				tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
 				tax_percent.text = str(flt(rate or 0, 2))
 
-			# Add exemption reason text if category requires it (E, AE, G, O, K)
 			if category_code in ["E", "AE", "G", "O", "K"]:
 				exemption_text = self._get_exemption_reason_text(category_code)
 				if exemption_text:

--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -392,12 +392,15 @@ class PEPPOLGenerator:
 
 		tax_category = ET.SubElement(item_elem, f"{{{self.namespaces['cac']}}}ClassifiedTaxCategory")
 
+		category_code = self.get_vat_category_code(self.invoice, item=item)
 		category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
-		category_id.text = self.get_vat_category_code(self.invoice, item=item)
+		category_id.text = category_code
 
-		item_tax_rate = self._get_item_tax_rate(item)
-		tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
-		tax_percent.text = str(flt(item_tax_rate or 0, 2))
+		# BR-O-05: O lines shall not contain VAT rate; BR-E-05: E lines require rate = 0
+		if category_code != "O":
+			item_tax_rate = self._get_item_tax_rate(item) if category_code not in ("E",) else 0
+			tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
+			tax_percent.text = str(flt(item_tax_rate or 0, 2))
 
 		tax_scheme = ET.SubElement(tax_category, f"{{{self.namespaces['cac']}}}TaxScheme")
 		scheme_id = ET.SubElement(tax_scheme, f"{{{self.namespaces['cbc']}}}ID")

--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -381,7 +381,7 @@ class PEPPOLGenerator:
 		tax_category = ET.SubElement(item_elem, f"{{{self.namespaces['cac']}}}ClassifiedTaxCategory")
 
 		category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
-		category_id.text = "S"
+		category_id.text = self.get_vat_category_code(self.invoice, item=item)
 
 		item_tax_rate = self._get_item_tax_rate(item)
 		tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
@@ -441,11 +441,32 @@ class PEPPOLGenerator:
 
 			tax_category = ET.SubElement(tax_subtotal, f"{{{self.namespaces['cac']}}}TaxCategory")
 
+			# Get category code dynamically from first item with this rate
+			category_code = None
+			sample_item = None
+			for item in self.invoice.items:
+				if self._get_item_tax_rate(item) == rate:
+					sample_item = item
+					category_code = self.get_vat_category_code(self.invoice, item=item)
+					break
+
+			if not category_code:
+				category_code = "S"  # Fallback to standard
+
 			category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
-			category_id.text = "S"
+			category_id.text = category_code
 
 			tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
 			tax_percent.text = str(flt(rate, 2))
+
+			# Add exemption reason text if category requires it (E, AE, G, O, K)
+			if category_code in ["E", "AE", "G", "O", "K"]:
+				exemption_text = self._get_exemption_reason_text(category_code)
+				if exemption_text:
+					exemption_reason = ET.SubElement(
+						tax_category, f"{{{self.namespaces['cbc']}}}TaxExemptionReason"
+					)
+					exemption_reason.text = exemption_text
 
 			tax_scheme = ET.SubElement(tax_category, f"{{{self.namespaces['cac']}}}TaxScheme")
 			scheme_id = ET.SubElement(tax_scheme, f"{{{self.namespaces['cbc']}}}ID")
@@ -614,17 +635,24 @@ class PEPPOLGenerator:
 			# Tax Category: Use the tax rate from invoice taxes
 			# Get the first non-Actual tax rate (usually VAT)
 			tax_rate = None
+			sample_tax = None
 			for tax in self.invoice.taxes:
 				if tax.charge_type != "Actual" and tax.rate:
 					tax_rate = tax.rate
+					sample_tax = tax
 					break
 
 			if tax_rate and tax_rate > 0:
 				tax_category = ET.SubElement(allowance_charge, f"{{{self.namespaces['cac']}}}TaxCategory")
 
+				# Get category code dynamically
+				category_code = (
+					self.get_vat_category_code(self.invoice, tax=sample_tax) if sample_tax else "S"
+				)
+
 				# Category ID
 				category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
-				category_id.text = "S"
+				category_id.text = category_code
 
 				tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
 				tax_percent.text = str(flt(tax_rate, 2))
@@ -659,9 +687,12 @@ class PEPPOLGenerator:
 				if tax.rate and tax.rate > 0:
 					tax_category = ET.SubElement(allowance_charge, f"{{{self.namespaces['cac']}}}TaxCategory")
 
+					# Get category code dynamically
+					category_code = self.get_vat_category_code(self.invoice, tax=tax)
+
 					# Category ID
 					category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
-					category_id.text = "S"
+					category_id.text = category_code
 
 					tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
 					tax_percent.text = str(flt(tax.rate, 2))
@@ -874,6 +905,7 @@ class PEPPOLGenerator:
 		if item:
 			lookup_records.extend(
 				[
+					("Item", getattr(item, "item_code", None)),
 					("Item Tax Template", getattr(item, "item_tax_template", None)),
 					("Account", getattr(item, "income_account", None)),
 				]
@@ -896,10 +928,40 @@ class PEPPOLGenerator:
 
 		lookup_records = [(doctype, name) for doctype, name in lookup_records if name]
 
-		# Get the VAT category code using CommonCodeRetriever
-		category_code = duty_tax_fee_category_codes.get(lookup_records)
+		# Check for explicit mapping only; fallback logic handles defaults below
+		category_code = duty_tax_fee_category_codes.get_code(lookup_records)
 
-		return category_code
+		if category_code:
+			return category_code
+
+		# Auto-detect Z (zero-rated) for 0% rates when no explicit mapping exists
+		tax_rate = None
+		if item:
+			tax_rate = self._get_item_tax_rate(item)
+		elif tax:
+			tax_rate = getattr(tax, "rate", None)
+
+		# 0% VAT line exists → Zero-rated (safe assumption, doesn't require exemption text)
+		if tax_rate is not None and flt(tax_rate) == 0:
+			return "Z"
+
+		# Default to S (standard) for everything else
+		return duty_tax_fee_category_codes.default_code or "S"
+
+	def _get_exemption_reason_text(self, category_code: str) -> str:
+		"""Get exemption reason text for PEPPOL validation.
+
+		Categories E, AE, G, O, K require either TaxExemptionReasonCode or TaxExemptionReason
+		per PEPPOL BIS business rules (BR-E-10, BR-AE-10, BR-G-10, BR-O-10, BR-IC-10).
+		"""
+		texts = {
+			"E": "Exempt from VAT",
+			"AE": "Reverse charge",
+			"G": "Export outside the EU",
+			"O": "Not subject to VAT",
+			"K": "Intra-community supply",
+		}
+		return texts.get(category_code, "")
 
 	def get_xml_bytes(self) -> bytes:
 		# Return the XML as bytes

--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -408,26 +408,31 @@ class PEPPOLGenerator:
 		tax_amount.text = str(flt(self.invoice.total_taxes_and_charges, 2))
 		tax_amount.set("currencyID", self.invoice.currency)
 
-		# Group taxes by rate from items
-		# Calculate taxes directly from items to ensure all tax rates are captured correctly
-		tax_rates = {}
+		# Group taxes by (category_code, rate)
+		# O items are not subject to VAT - no rate needed; E items require rate=0
+		tax_groups = {}
 		for item in self.invoice.items:
-			rate = self._get_item_tax_rate(item)
+			category_code = self.get_vat_category_code(self.invoice, item=item)
 
-			if not rate or rate == 0:
-				continue
+			# O is not subject to VAT - no rate; E is exempt with rate=0
+			if category_code == "O":
+				rate = None
+			elif category_code == "E":
+				rate = 0
+			else:
+				rate = self._get_item_tax_rate(item) or 0
 
-			if rate not in tax_rates:
-				tax_rates[rate] = {"taxable_amount": 0, "tax_amount": 0}
+			key = (category_code, rate)
 
-			# Calculate tax amount for this item
-			# item.net_amount is already after item-level discounts
-			item_tax_amount = flt(item.net_amount) * rate / 100
-			tax_rates[rate]["tax_amount"] += item_tax_amount
-			tax_rates[rate]["taxable_amount"] += flt(item.net_amount)
+			if key not in tax_groups:
+				tax_groups[key] = {"taxable_amount": 0, "tax_amount": 0}
 
-		# Add TaxSubtotal for each rate
-		for rate, data in tax_rates.items():
+			item_tax_amount = flt(item.net_amount) * (rate or 0) / 100
+			tax_groups[key]["tax_amount"] += item_tax_amount
+			tax_groups[key]["taxable_amount"] += flt(item.net_amount)
+
+		# Add TaxSubtotal for each (category, rate) group
+		for (category_code, rate), data in tax_groups.items():
 			tax_subtotal = ET.SubElement(tax_total, f"{{{self.namespaces['cac']}}}TaxSubtotal")
 
 			taxable_amount = ET.SubElement(tax_subtotal, f"{{{self.namespaces['cbc']}}}TaxableAmount")
@@ -456,8 +461,10 @@ class PEPPOLGenerator:
 			category_id = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}ID")
 			category_id.text = category_code
 
-			tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
-			tax_percent.text = str(flt(rate, 2))
+			# BR-48: O (Not subject to VAT) has no rate; all others require Percent
+			if category_code != "O":
+				tax_percent = ET.SubElement(tax_category, f"{{{self.namespaces['cbc']}}}Percent")
+				tax_percent.text = str(flt(rate or 0, 2))
 
 			# Add exemption reason text if category requires it (E, AE, G, O, K)
 			if category_code in ["E", "AE", "G", "O", "K"]:

--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -76,6 +76,16 @@ class PEPPOLGenerator:
 		document_type = DOCUMENT_TYPE_MAPPING.get(invoice_type_code, "Invoice")
 		return document_type
 
+	def _has_out_of_scope_items(self) -> bool:
+		"""Check if any invoice line has VAT category 'O' (Out of Scope).
+
+		Per PEPPOL BR-O-02: invoices with O items shall not contain VAT identifiers.
+		"""
+		for item in self.invoice.items:
+			if self.get_vat_category_code(self.invoice, item=item) == "O":
+				return True
+		return False
+
 	def create_einvoice(self):
 		# Create the PEPPOL XML document
 		try:
@@ -226,7 +236,8 @@ class PEPPOLGenerator:
 			else:
 				country_code.text = "DE"
 
-		if self.invoice.company_tax_id:
+		# BR-O-02: Omit VAT identifiers if any item is Out of Scope
+		if self.invoice.company_tax_id and not self._has_out_of_scope_items():
 			tax_scheme = ET.SubElement(party, f"{{{self.namespaces['cac']}}}PartyTaxScheme")
 			company_id = ET.SubElement(tax_scheme, f"{{{self.namespaces['cbc']}}}CompanyID")
 			company_id.text = self.invoice.company_tax_id
@@ -310,7 +321,8 @@ class PEPPOLGenerator:
 			else:
 				country_code.text = "DE"
 
-		if self.invoice.tax_id:
+		# BR-O-02: Omit VAT identifiers if any item is Out of Scope
+		if self.invoice.tax_id and not self._has_out_of_scope_items():
 			tax_scheme = ET.SubElement(party, f"{{{self.namespaces['cac']}}}PartyTaxScheme")
 			company_id = ET.SubElement(tax_scheme, f"{{{self.namespaces['cbc']}}}CompanyID")
 			company_id.text = self.invoice.tax_id


### PR DESCRIPTION
## Problem

PEPPOL invoices with Zero-rated (Z), Exempt (E), or Out of Scope (O) items 
failed validation due to incorrect tax category handling.

## Changes

- **Z detection**: Use explicit mapping check before defaulting, allowing 0% 
  rates to correctly resolve to "Z"
- **Tax breakdown**: Group by (category, rate) so E/O/Z get separate TaxSubtotal 
  entries with correct codes
- **BR-O-02**: Omit seller/buyer VAT identifiers when invoice contains O items
- **BR-O-05**: O line items have no VAT rate element
- **BR-E-05**: E line items have VAT rate = 0
- **BR-48**: Only O category skips Percent in TaxSubtotal

## Documentation
A new section has been added to the readme to document the required configuration.