### PR TITLE
fix: prevent modifications to transmitted edocuments

### DIFF
--- a/edocument/edocument/doctype/edocument/edocument.js
+++ b/edocument/edocument/doctype/edocument/edocument.js
@@ -8,8 +8,10 @@ frappe.ui.form.on("EDocument", {
 });
 
 function setup_action_buttons(frm) {
-	// Generate XML - for outgoing documents
-	if (frm.doc.edocument_source_document && frm.doc.edocument_profile) {
+	const is_transmitted = frm.doc.status === "Transmission Successful";
+
+	// Generate XML - for outgoing documents (not already transmitted)
+	if (frm.doc.edocument_source_document && frm.doc.edocument_profile && !is_transmitted) {
 		frm.add_custom_button(
 			__("Generate XML"),
 			() => {
@@ -35,7 +37,11 @@ function setup_action_buttons(frm) {
 			if (!r.message && !frm.doc.xml_file) return;
 
 			frm.add_custom_button(__("Preview EDocument"), () => show_preview(frm), __("Actions"));
-			frm.add_custom_button(__("Validate XML"), () => validate_xml(frm), __("Actions"));
+
+			if (!is_transmitted) {
+				frm.add_custom_button(__("Validate XML"), () => validate_xml(frm), __("Actions"));
+			}
+
 			frm.add_custom_button(__("Match Document"), () => match_document(frm), __("Actions"));
 			frm.add_custom_button(
 				__("Create Document"),

--- a/edocument/edocument/doctype/edocument/edocument.json
+++ b/edocument/edocument/doctype/edocument/edocument.json
@@ -65,7 +65,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "\nValidation Successful\nValidation Failed\nMatching Successful\nMatching Failed\nTransmission Successful\nTransmission Failed"
+   "options": "\nValidation Successful\nValidation Failed\nMatching Successful\nMatching Failed\nTransmission Successful\nTransmission Failed",
+   "read_only": 1
   },
   {
    "fieldname": "country",

--- a/edocument/edocument/doctype/edocument/edocument.py
+++ b/edocument/edocument/doctype/edocument/edocument.py
@@ -120,6 +120,9 @@ class EDocument(Document):
 		Note: This method only generates XML - validation is handled separately.
 		This is the public method called from the button.
 		"""
+		if self.status == "Transmission Successful":
+			frappe.throw(_("Cannot regenerate XML for an already transmitted document."))
+
 		try:
 			file_name = self._generate_xml_internal()
 			# Save the document to persist status and error field changes
@@ -219,6 +222,9 @@ class EDocument(Document):
 		Updates the status and error fields based on validation results.
 		This is the public method called from the button.
 		"""
+		if self.status == "Transmission Successful":
+			frappe.throw(_("Cannot re-validate an already transmitted document."))
+
 		try:
 			self._validate_xml_internal()
 			# Save the document to persist status and error field changes
@@ -301,7 +307,13 @@ class EDocument(Document):
 						f"Error during automatic XML generation for EDocument {self.name}: {error_msg}"
 					)
 
-		if self.edocument_profile:
+		# Don't overwrite status for documents that reached a terminal state
+		# (already transmitted or matched) — re-validation would reset status
+		# back to "Validation Successful" and re-enable the Send button.
+		terminal_statuses = ("Transmission Successful", "Transmission Failed",
+			"Matching Successful", "Matching Failed")
+
+		if self.edocument_profile and self.status not in terminal_statuses:
 			# Validate XML automatically
 			try:
 				self._validate_xml_internal()

--- a/edocument/edocument/doctype/edocument/edocument.py
+++ b/edocument/edocument/doctype/edocument/edocument.py
@@ -310,8 +310,12 @@ class EDocument(Document):
 		# Don't overwrite status for documents that reached a terminal state
 		# (already transmitted or matched) — re-validation would reset status
 		# back to "Validation Successful" and re-enable the Send button.
-		terminal_statuses = ("Transmission Successful", "Transmission Failed",
-			"Matching Successful", "Matching Failed")
+		terminal_statuses = (
+			"Transmission Successful",
+			"Transmission Failed",
+			"Matching Successful",
+			"Matching Failed",
+		)
 
 		if self.edocument_profile and self.status not in terminal_statuses:
 			# Validate XML automatically


### PR DESCRIPTION
Once an EDocument reaches a terminal state (`Transmission Successful`, `Transmission Failed`, `Matching Successful`, `Matching Failed`), it should be treated as immutable.

Without this fix, `before_save` re-runs XML validation on every save, which resets the status back to `Validation Successful` — re-enabling the Send button on an already-transmitted document. Additionally, the `status` field was editable by users, allowing manual overrides of system-managed state.

### Changes

**Server-side** (`edocument.py`):
- `generate_xml()` and `validate_xml()` now throw if status is `Transmission Successful`
- `before_save` skips automatic re-validation for documents in terminal statuses

**Client-side** (`edocument.js`):
- Hides "Generate XML" and "Validate XML" buttons for transmitted documents

**DocType definition** (`edocument.json`):
- `status` field is now `read_only` — it is entirely system-managed (set by validation, matching, and transmission logic), so users should not be able to manually override it