### PR TITLE
chore: add apt deploy dependencies for lxml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,9 @@ typing-modules = ["frappe.types.DF"]
 quote-style = "double"
 indent-style = "tab"
 docstring-code-format = true
+
+[deploy.dependencies.apt]
+packages = [
+    "libxml2-dev",
+    "libxslt-dev",
+]


### PR DESCRIPTION
Declares `libxml2-dev` and `libxslt-dev` in `[deploy.dependencies.apt]` so that `lxml` can compile from source on deploy targets that don't ship prebuilt wheels. Without these packages, `pip install` fails and blocks the entire app installation.

Please backport to `version-16`.