### PR TITLE
Fix/html description and no copy

### DIFF
--- a/edocument/edocument/profiles/peppol/generator.py
+++ b/edocument/edocument/profiles/peppol/generator.py
@@ -458,7 +458,12 @@ class PEPPOLGenerator:
 		item_elem = ET.SubElement(invoice_line, f"{{{self.namespaces['cac']}}}Item")
 
 		description = ET.SubElement(item_elem, f"{{{self.namespaces['cbc']}}}Description")
-		description.text = item.description or item.item_name
+		item_description = item.description or item.item_name
+		if frappe.utils.is_html(item_description):
+			from frappe.core.utils import html2text
+
+			item_description = html2text(item_description).strip()
+		description.text = item_description
 
 		name = ET.SubElement(item_elem, f"{{{self.namespaces['cbc']}}}Name")
 		name.text = item.item_name

--- a/edocument/install.py
+++ b/edocument/install.py
@@ -125,6 +125,7 @@ def get_custom_fields():
 				"options": "EDocument",
 				"insert_after": "edocument_profile",
 				"read_only": 1,
+				"no_copy": 1,
 			},
 			{
 				"fieldname": "edocument_status",
@@ -133,6 +134,7 @@ def get_custom_fields():
 				"insert_after": "edocument",
 				"fetch_from": "edocument.status",
 				"read_only": 1,
+				"no_copy": 1,
 			},
 		],
 		"Purchase Invoice": [
@@ -149,6 +151,7 @@ def get_custom_fields():
 				"options": "EDocument",
 				"insert_after": "edocument_tab",
 				"read_only": 1,
+				"no_copy": 1,
 			},
 			{
 				"fieldname": "edocument_status",
@@ -157,6 +160,7 @@ def get_custom_fields():
 				"insert_after": "edocument",
 				"fetch_from": "edocument.status",
 				"read_only": 1,
+				"no_copy": 1,
 			},
 		],
 	}


### PR DESCRIPTION
- Convert HTML item descriptions to plain text using html2text before writing to PEPPOL XML, preserving paragraph breaks
- Add no_copy to edocument and edocument_status fields on Sales Invoice and Purchase Invoice to prevent copying when duplicating invoices